### PR TITLE
Update guava to 24.1.1 per Dependabot alert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>15.0</version>
+            <version>24.1.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
For some reason Dependabot didn't send a PR so doing this manually.

CVE-2018-10237
moderate severity
Vulnerable versions: > 11.0, < 24.1.1
Patched version: 24.1.1
Unbounded memory allocation in Google Guava 11.0 through 24.x before 24.1.1 allows remote attackers to conduct denial of service attacks against servers that depend on this library and deserialize attacker-provided data, because the AtomicDoubleArray class (when serialized with Java serialization) and the CompoundOrdering class (when serialized with GWT serialization) perform eager allocation without appropriate checks on what a client has sent and whether the data size is reasonable.